### PR TITLE
Added Xcode for macOS in c-ide-compiler.org

### DIFF
--- a/c-ide-compiler.org
+++ b/c-ide-compiler.org
@@ -55,3 +55,5 @@ CLion that I would recommend reading if you want to use it.
 If you don't want to use CLion, vscode or any other text editor are always options too. Just fire up
 a text editor and write your C code, then open a terminal to compile your code. You can also make
 use of ~Makefile~ or ~CMake~ to ensure that your project can easily be compiled and executed.
+
+For MacOS only, you can download XCode directly from the App Store. When successfully downloaded, you start coding, by clicking on "Create a new XCode project then under the macOS tab, select "Command Line Tool". Then for the Language, select C. A main.c file will be created for you. And you are done! You can now write and compile your code. XCode is also equipped with debugging, auto-completon, error/warning reporting...


### PR DESCRIPTION
Steps to setup and run a C project on XCode, for MacOS users.